### PR TITLE
Add alias to allow running tests in OSP13

### DIFF
--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -1,5 +1,16 @@
 #!usr/bin/env ansible-playbook
 ---
+- name: "Add alias for OSP13 to use docker instead of podman"
+  hosts: overcloud_nodes
+  become: true
+  tags:
+    - OSP13
+  tasks:
+    - lineinfile:
+        path: /root/.bashrc
+        line: "alias podman='docker'"
+        create: yes
+
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes
   become: true

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -1,15 +1,17 @@
 #!usr/bin/env ansible-playbook
 ---
-- name: "Add alias for OSP13 to use docker instead of podman"
+- name: "Add symlink for podman->docker so we don't have to change the commands in OSP13"
   hosts: overcloud_nodes
   become: true
   tags:
     - OSP13
   tasks:
-    - lineinfile:
-        path: /root/.bashrc
-        line: "alias podman='docker'"
-        create: yes
+    - file:
+        src: /usr/bin/docker
+        dest: /usr/bin/podman
+        owner: root
+        group: wheel
+        state: link
 
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes


### PR DESCRIPTION
OSP13 uses docker instead of podman, this change adds an alias for root user so `podman` maps to `docker`, so CI can run against OSP13 and OSP16 without separate branches needed to resolve the differences.