### PR TITLE
Add summary log file for tests

### DIFF
--- a/README
+++ b/README
@@ -32,9 +32,15 @@ OR
 
     ansible-playbook -i `infrared workspace inventory` stf_functional_tests.yml --tags "<one of the tags from above>"
 
+To get a summarised output of the tests at the end, whitelist the provided logging callback.::
+
+    ANSIBLE_CALLBACK_WHITELIST=custom_logger ansible-playbook -i `infrared workspace inventory` stf_functional_tests.yml
+
+The logging callback will summarise the tests run on each node and whether they passes or failed.
+The callback will only report on the status of tasks that have a name beinging with "[Test]".
 
 Note::
-    If you haven't deployed using infrared, youcan still run the tests if you create your own inventory file, containing one group of hosts called ``overcloud_nodes``.
+    If you haven't deployed using infrared, you can still run the tests if you create your own inventory file, containing one group of hosts called ``overcloud_nodes``.
 
 
 Adding new tests
@@ -54,7 +60,7 @@ The changes required in this repo for tests is a new role in ``run_stf_tests.yml
         - collectd-write-qdr-mesh
         - some-other-template-name
       tasks:
-        - name: My test name
+        - name: "[Test] My test name"
           shell: |
               my_test_command
           register: command_output

--- a/callback_plugins/custom_logger.py
+++ b/callback_plugins/custom_logger.py
@@ -1,0 +1,67 @@
+from __future__ import (absolute_import, division, print_function)
+#__metaclass__ = type
+
+import os
+
+from ansible.plugins.callback import CallbackBase
+
+DOCUMENTATION = '''
+    callback: log_to_file
+    type: notification
+    short_description: output logs to a file
+    description:
+        - This summarises tasks per host and outputs it to a log file
+'''
+
+MSG_FORMAT = "{host} {task}: {status}\n"
+
+class CallbackModule(CallbackBase):
+    """
+    logs playbook results, per host, in /var/log/ansible/hosts
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'log_to_file'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    MSG_FORMAT = "{host} {task}: {status}\n"
+
+    def __init__(self):
+
+        super(CallbackModule, self).__init__()
+        self.current_task = ''
+        self.passed = 0
+        self.failed = 0
+        self.path = os.path.join(os.getcwd(), "stf_test_run_results.txt")
+        # either create the file or truncate the existing file
+        with open(self.path, 'w') as fp:
+            pass
+
+    def playbook_on_task_start(self, task, is_conditional):
+        self.current_task = str(task)
+
+    def playbook_on_stats(self, stats):
+        with open(self.path, 'a') as fd:
+            fd.write("PASSED: {}\n".format(self.passed))
+            fd.write("FAILED: {}\n".format(self.failed))
+
+    def log(self, host, category):
+        # only interested in the test tasks, not setup or debug
+        if self.current_task.startswith("[Test]"):
+
+            if category == "FAIL":
+               self.failed +=1
+            if category == "PASS":
+                self.passed +=1
+     
+            with open(self.path, 'a') as fd:
+                fd.write(self.MSG_FORMAT.format(host=host, task=self.current_task, status=category))
+
+    def runner_on_failed(self, host, res, ignore_errors=False):
+        self.log(host, 'FAIL')
+
+    def runner_on_ok(self, host, res):
+        self.log(host, 'PASS')
+
+    def runner_on_skipped(self, host, res, item=None):
+        self.log(host, 'SKIP')

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -1,5 +1,24 @@
 #!usr/bin/env ansible-playbook
 ---
+- name: "Create output file on undercloud machine"
+  hosts: undercloud-0
+  gather_facts: false
+  vars:
+    output_file: stf_test_run_results.txt
+  tasks:
+      - name: Delete old file if existing
+        file:
+          path: "{{ output_file }}"
+          state: absent
+        ignore_errors: true
+
+
+      - name: Create output file
+        file:
+          path: "{{ output_file }}"
+          mode: "u=rw,g=r,o=r"
+          state: touch
+
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes
   become: true
@@ -8,25 +27,39 @@
     - collectd-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: "[Test] Check that collectd container is running"
-        shell: |
-            podman ps | grep collectd
-        register: collectd
-        failed_when: collectd.stdout_lines|length != 1
+      - name: Check that collectd container is running.
+        shell: podman ps
+        register: podman_nodes
+
+      - set_fact:
+          status_string: "PASS"
+        when: "'collectd' in podman_nodes['stdout']"
+
+      - name: write to the file
+        lineinfile:
+          path: /home/stack/stf_test_run_results.txt
+          line: "{{ inventory_hostname }} collectd container status: {{ status_string | default('FAIL') }}"
+        delegate_to: "{{ groups['undercloud'] | first }}"
 
       - name: "[Test] Check for a non-zero number of metrics from collectd"
-        shell: |
-            podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
+        shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
         register: num_metrics
-        failed_when: num_metrics.stdout|int == 0
+      - set_fact:
+          metrics_status: "PASS"
+        when: "num_metrics.stdout|int != 0"
+
+      - name: write to the file
+        lineinfile:
+          path: /home/stack/stf_test_run_results.txt
+          line: "{{ inventory_hostname }} collectd metrics status: {{ metrics_status | default('FAIL') }}"
+        delegate_to: "{{ groups['undercloud'] | first }}"
 
       - name: "[Debug] Check for a non-zero number of metrics from collectd"
         debug:
            var: num_metrics
 
       - name: "[Setup] Get the value of some metric from collectd"
-        shell: |
-            podman exec collectd collectdctl -s /var/run/collectd-socket listval | tail -1
+        shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | tail -1
         register: met
 
       - name: "[Debug] Get the value of some metric from collectd"
@@ -34,10 +67,20 @@
           var: met
 
       - name: "[Test] Get the value of some metric from collectd"
-        shell: |
-            podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
+        shell: podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
         register: stat
-        failed_when: stat.stdout_lines|length < 1
+        ignore_errors: yes
+      - set_fact:
+          metrics_value: "PASS"
+        when: "stat.stdout_lines|length == 1"
+        ignore_errors: yes
+
+      - name: write to the file
+        lineinfile:
+          path: /home/stack/stf_test_run_results.txt
+          line: "{{ inventory_hostname }} collectd metrics value status: {{ metrics_value | default('FAIL') }}"
+        delegate_to: "{{ groups['undercloud'] | first }}"
+
 
 - name: "Check that metrics_qdr container is running and receiving ANY messages."
   hosts: overcloud_nodes
@@ -49,11 +92,19 @@
     - ceilometer-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: "[Test] Check that the metrics_qdr container is running"
-        shell: |
-           podman ps | grep metrics_qdr
-        register: qdr
-        failed_when: qdr.stdout_lines|length != 1
+      - name: Check that qdr container is running.
+        shell: podman ps
+        register: podman_nodes
+
+      - set_fact:
+          qdr_status: "PASS"
+        when: "'metrics_qdr' in podman_nodes['stdout']"
+
+      - name: write to the file
+        lineinfile:
+          path: /home/stack/stf_test_run_results.txt
+          line: "{{ inventory_hostname }} metrics_qdr  container status: {{ qdr_status | default('FAIL') }}"
+        delegate_to: "{{ groups['undercloud'] | first }}"
 
       - name: "[Setup] Get Qdr bus address"
         shell: |
@@ -65,11 +116,31 @@
           var: bus_addr
 
       - name: "[Test] Get number of messages received"
-        shell: |
-             podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
+        shell: podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
         register: num_rx
-        failed_when: num_rx.stdout|int == 0
+        ignore_errors: true
+      - set_fact:
+          messages_value: "PASS"
+        when: num_rx.stdout|int != 0
 
+
+      - name: write to the file
+        lineinfile:
+          path: /home/stack/stf_test_run_results.txt
+          line: "{{ inventory_hostname }} metrics_qdr number of messages: {{ messages_value | default('FAIL') }}"
+        delegate_to: "{{ groups['undercloud'] | first }}"
       - name: "[Debug] Get the number of messages received"
         debug:
           var: num_rx
+
+- name: Count passed and failed tests
+  hosts: undercloud-0
+  gather_facts: false
+  tasks:
+      - name:
+        shell: |
+          echo "PASS: `less stf_test_run_results.txt | grep PASS -c`" >> stf_test_run_results.txt
+          echo "FAIL: `less stf_test_run_results.txt | grep FAIL -c`" >> stf_test_run_results.txt
+        register: command_result
+        ignore_errors: true
+        delegate_to: "{{ groups['undercloud'] | first }}"

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -1,58 +1,26 @@
 #!usr/bin/env ansible-playbook
 ---
-- name: "Create output file on undercloud machine"
-  hosts: undercloud-0
-  gather_facts: false
-  vars:
-    output_file: stf_test_run_results.txt
-  tasks:
-      - name: Delete old file if existing
-        file:
-          path: "{{ output_file }}"
-          state: absent
-        ignore_errors: true
-
-
-      - name: Create output file
-        file:
-          path: "{{ output_file }}"
-          mode: "u=rw,g=r,o=r"
-          state: touch
-
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes
+  ignore_errors: true
   become: true
   tags:
     - collectd-write-qdr-edge-only
     - collectd-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: Check that collectd container is running.
-        shell: podman ps
+      - name: "[Test] Check that collectd container is running."
+        shell: |
+          podman ps | grep collectd
         register: podman_nodes
-
-      - set_fact:
-          status_string: "PASS"
-        when: "'collectd' in podman_nodes['stdout']"
-
-      - name: write to the file
-        lineinfile:
-          path: /home/stack/stf_test_run_results.txt
-          line: "{{ inventory_hostname }} collectd container status: {{ status_string | default('FAIL') }}"
-        delegate_to: "{{ groups['undercloud'] | first }}"
+        failed_when: podman_nodes.stdout_lines|length != 1
 
       - name: "[Test] Check for a non-zero number of metrics from collectd"
-        shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
+        shell: |
+          podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
         register: num_metrics
-      - set_fact:
-          metrics_status: "PASS"
-        when: "num_metrics.stdout|int != 0"
+        failed_when: "not (num_metrics.stdout|int !=0 )"
 
-      - name: write to the file
-        lineinfile:
-          path: /home/stack/stf_test_run_results.txt
-          line: "{{ inventory_hostname }} collectd metrics status: {{ metrics_status | default('FAIL') }}"
-        delegate_to: "{{ groups['undercloud'] | first }}"
 
       - name: "[Debug] Check for a non-zero number of metrics from collectd"
         debug:
@@ -69,21 +37,11 @@
       - name: "[Test] Get the value of some metric from collectd"
         shell: podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
         register: stat
-        ignore_errors: yes
-      - set_fact:
-          metrics_value: "PASS"
-        when: "stat.stdout_lines|length == 1"
-        ignore_errors: yes
-
-      - name: write to the file
-        lineinfile:
-          path: /home/stack/stf_test_run_results.txt
-          line: "{{ inventory_hostname }} collectd metrics value status: {{ metrics_value | default('FAIL') }}"
-        delegate_to: "{{ groups['undercloud'] | first }}"
-
+        failed_when: not(stat.stdout_lines|length == 1)
 
 - name: "Check that metrics_qdr container is running and receiving ANY messages."
   hosts: overcloud_nodes
+  ignore_errors: true
   become: true
   tags:
     - collectd-write-qdr-edge-only
@@ -92,19 +50,11 @@
     - ceilometer-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: Check that qdr container is running.
-        shell: podman ps
+      - name: "[Test] Check that qdr container is running."
+        shell: |
+          podman ps | grep collectd
         register: podman_nodes
-
-      - set_fact:
-          qdr_status: "PASS"
-        when: "'metrics_qdr' in podman_nodes['stdout']"
-
-      - name: write to the file
-        lineinfile:
-          path: /home/stack/stf_test_run_results.txt
-          line: "{{ inventory_hostname }} metrics_qdr  container status: {{ qdr_status | default('FAIL') }}"
-        delegate_to: "{{ groups['undercloud'] | first }}"
+        failed_when: podman_nodes.stdout_lines|length != 1
 
       - name: "[Setup] Get Qdr bus address"
         shell: |
@@ -118,29 +68,9 @@
       - name: "[Test] Get number of messages received"
         shell: podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
         register: num_rx
-        ignore_errors: true
-      - set_fact:
-          messages_value: "PASS"
-        when: num_rx.stdout|int != 0
+        failed_when: num_rx.stdout|int == 0 or num_rx.stdout_lines|length == 0
 
-
-      - name: write to the file
-        lineinfile:
-          path: /home/stack/stf_test_run_results.txt
-          line: "{{ inventory_hostname }} metrics_qdr number of messages: {{ messages_value | default('FAIL') }}"
-        delegate_to: "{{ groups['undercloud'] | first }}"
       - name: "[Debug] Get the number of messages received"
         debug:
           var: num_rx
 
-- name: Count passed and failed tests
-  hosts: undercloud-0
-  gather_facts: false
-  tasks:
-      - name:
-        shell: |
-          echo "PASS: `less stf_test_run_results.txt | grep PASS -c`" >> stf_test_run_results.txt
-          echo "FAIL: `less stf_test_run_results.txt | grep FAIL -c`" >> stf_test_run_results.txt
-        register: command_result
-        ignore_errors: true
-        delegate_to: "{{ groups['undercloud'] | first }}"


### PR DESCRIPTION
Update to @lnatapov's  change to log test summary to file.

This approach uses an ansible callback and produces the same output format.
The file is currently placed in the directory which the playbook is called from.

The callback can be used either by passing a config variable::
ANSIBLE_CALLBACK_WHITELIST=custom_logger ansible-playbook -i `infrared workspace inventory` stf_functional_tests.yml
or by including ``callback_whitelist = custom_logger`` in the [defaults] section of the ansible.cfg
