### PR TITLE
Reorg tests and add config to all reusing of the tests

### DIFF
--- a/README
+++ b/README
@@ -84,3 +84,14 @@ The task can then be imported in ``stf_functional_tests.yml`` like so::
 ```
 
 
+Configuration
+-------------
+The following vars can be passed to change the bahaviour.
+
+* collectd_container_name
+  The name of the container where collectd is running, e.g. ``collectd-test``
+  default: ``collectd``
+
+* qdr_container_name
+  The name of the container where qdr is running, e.g. ``metrics_qdr``, ``qdr-test``
+  default: ``metrics_qdr``

--- a/README
+++ b/README
@@ -41,18 +41,37 @@ The callback will only report on the status of tasks that have a name beinging w
 
 Note::
     If you haven't deployed using infrared, you can still run the tests if you create your own inventory file, containing one group of hosts called ``overcloud_nodes``.
-
+    Alternatively, you can create your own playbook that imports the tasks in ``tasks/*.yml``
 
 Adding new tests
 ----------------
 
-Adding a new test for existing deployment templates requires no changes in Jenkins.
-Adding tests for new deployment templates requires that the template is in Infrared and deployed in Jenkins.
+Adding a new test for existing deployment templates requires no changes in
+Jenkins.
+Adding tests for new deployment templates requires that the template is in
+Infrared and deployed in Jenkins.
 
-The changes required in this repo for tests is a new role in ``run_stf_tests.yml`` with a tag, e.g.::
+The changes required in this repo for tests is to add additional tasks under
+``tasks/test_<your_test_name>.yml``.
 
 ```
-    - name: Collectd checks
+     - name: "[Test] My test name"
+       shell: |
+           my_test_command
+       register: command_output
+       failed_when: command_output.stdout == some_value
+
+```
+
+Most of the functional tests are a series of shell commands that one would run
+when verifying that particular features were deployed correctly, and can be
+adapted from any manual testing that is done.
+
+
+The task can then be imported in ``stf_functional_tests.yml`` like so::
+
+```
+     - name: Collectd checks
       hosts: overcloud_nodes
       become: true
       tags:
@@ -60,13 +79,8 @@ The changes required in this repo for tests is a new role in ``run_stf_tests.yml
         - collectd-write-qdr-mesh
         - some-other-template-name
       tasks:
-        - name: "[Test] My test name"
-          shell: |
-              my_test_command
-          register: command_output
-          failed_when: command_output.stdout == some_value
+        - import_tasks: tasks/test_<your_test_name>
 
 ```
 
-Most of the functional tests are a series of shell commands that one would run when verifying that particular features were deployed correctly, and can be adapted from any manual testing that is done.
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ The deployment templates are in infrared, and have the following names:
  - 'ceilometer-write-qdr-mesh'
  - 'enable-stf'
 
-The tags for the ansible playbook correspond to these templates and run the appropriate trests for each deployment.
+The tags for the ansible playbook correspond to these templates and run the appropriate tests for each deployment.
 
 The current set of functional tests are:
 
@@ -86,7 +86,7 @@ The task can then be imported in ``stf_functional_tests.yml`` like so::
 
 Configuration
 -------------
-The following vars can be passed to change the bahaviour.
+The following vars can be passed to change the behaviour.
 
 * collectd_container_name
   The name of the container where collectd is running, e.g. ``collectd-test``

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ adapted from any manual testing that is done.
 The task can then be imported in ``stf_functional_tests.yml`` like so::
 
 ```
-     - name: Collectd checks
+    - name: Collectd checks
       hosts: overcloud_nodes
       become: true
       tags:

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,8 @@ The task can then be imported in ``stf_functional_tests.yml`` like so::
     - name: Collectd checks
       hosts: overcloud_nodes
       become: true
+      roles:
+        - "{{ playbook_dir }}"
       tags:
         - collectd-write-qdr-edge-only
         - collectd-write-qdr-mesh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+collectd_container_name: 'collectd'
+qdr_container_name: 'metrics_qdr'

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -22,35 +22,7 @@
     - collectd-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: "[Test] Check that collectd container is running."
-        shell: |
-          podman ps | grep collectd
-        register: podman_nodes
-        failed_when: podman_nodes.stdout_lines|length != 1
-
-      - name: "[Test] Check for a non-zero number of metrics from collectd"
-        shell: |
-          podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
-        register: num_metrics
-        failed_when: "not (num_metrics.stdout|int !=0 )"
-
-
-      - name: "[Debug] Check for a non-zero number of metrics from collectd"
-        debug:
-           var: num_metrics
-
-      - name: "[Setup] Get the value of some metric from collectd"
-        shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | tail -1
-        register: met
-
-      - name: "[Debug] Get the value of some metric from collectd"
-        debug:
-          var: met
-
-      - name: "[Test] Get the value of some metric from collectd"
-        shell: podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
-        register: stat
-        failed_when: not(stat.stdout_lines|length == 1)
+    - import_tasks: tasks/test_collectd.yml
 
 - name: "Check that metrics_qdr container is running and receiving ANY messages."
   hosts: overcloud_nodes
@@ -63,27 +35,4 @@
     - ceilometer-write-qdr-mesh
     - enable-stf
   tasks:
-      - name: "[Test] Check that qdr container is running."
-        shell: |
-          podman ps | grep metrics_qdr
-        register: podman_nodes
-        failed_when: podman_nodes.stdout_lines|length != 1
-
-      - name: "[Setup] Get Qdr bus address"
-        shell: |
-            podman exec metrics_qdr cat /etc/qpid-dispatch/qdrouterd.conf | grep -5 listener | grep -3 "port: 5666" | grep host | awk '{print $2}'
-        register: bus_addr
-
-      - name: "[Debug] Get Qdr bus address"
-        debug:
-          var: bus_addr
-
-      - name: "[Test] Get number of messages received"
-        shell: podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
-        register: num_rx
-        failed_when: num_rx.stdout|int == 0 or num_rx.stdout_lines|length == 0
-
-      - name: "[Debug] Get the number of messages received"
-        debug:
-          var: num_rx
-
+    - import_tasks: tasks/test_qdr.yml

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -16,26 +16,19 @@
   hosts: overcloud_nodes
   ignore_errors: true
   become: true
-  roles:
-    - "{{ playbook_dir }}"
-  tags:
-    - collectd-write-qdr-edge-only
-    - collectd-write-qdr-mesh
-    - enable-stf
   tasks:
-    - import_tasks: tasks/test_collectd.yml
-
-- name: "Check that metrics_qdr container is running and receiving ANY messages."
-  hosts: overcloud_nodes
-  ignore_errors: true
-  become: true
-  roles:
-    - "{{ playbook_dir }}"
-  tags:
-    - collectd-write-qdr-edge-only
-    - collectd-write-qdr-mesh
-    - ceilometer-write-qdr-edge-only
-    - ceilometer-write-qdr-mesh
-    - enable-stf
-  tasks:
-    - import_tasks: tasks/test_qdr.yml
+    - import_role: name="{{ playbook_dir }}"
+    - name: "Run collectd tests"
+      import_tasks: tasks/test_collectd.yml
+      tags:
+        - collectd-write-qdr-edge-only
+        - collectd-write-qdr-mesh
+        - enable-stf
+    - name: "Run metrics_qdr tests"
+      import_tasks: tasks/test_qdr.yml
+      tags:
+        - collectd-write-qdr-edge-only
+        - collectd-write-qdr-mesh
+        - ceilometer-write-qdr-edge-only
+        - ceilometer-write-qdr-mesh
+        - enable-stf

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -1,4 +1,3 @@
-#!usr/bin/env ansible-playbook
 ---
 - name: "Add symlink for podman->docker so we don't have to change the commands in OSP13"
   hosts: overcloud_nodes
@@ -13,32 +12,12 @@
         group: wheel
         state: link
 
-- name: "Set up defaults"
-  hosts: overcloud_nodes
-  tags: always
-  tasks:
-    - include_vars:
-        file: defaults/main.yml
-        name: play_vars
-
-    - set_fact: "{{item.key}}={{item.value}}"
-      loop: "{{ play_vars|dict2items}}"
-
-- name: "Set up defaults"
-  hosts: overcloud_nodes
-  tags: always
-  tasks:
-    - include_vars:
-        file: defaults/main.yml
-        name: play_vars
-
-    - set_fact: "{{item.key}}={{item.value}}"
-      loop: "{{ play_vars|dict2items}}"
-
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes
   ignore_errors: true
   become: true
+  roles:
+    - "{{ playbook_dir }}"
   tags:
     - collectd-write-qdr-edge-only
     - collectd-write-qdr-mesh
@@ -50,6 +29,8 @@
   hosts: overcloud_nodes
   ignore_errors: true
   become: true
+  roles:
+    - "{{ playbook_dir }}"
   tags:
     - collectd-write-qdr-edge-only
     - collectd-write-qdr-mesh

--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -13,6 +13,28 @@
         group: wheel
         state: link
 
+- name: "Set up defaults"
+  hosts: overcloud_nodes
+  tags: always
+  tasks:
+    - include_vars:
+        file: defaults/main.yml
+        name: play_vars
+
+    - set_fact: "{{item.key}}={{item.value}}"
+      loop: "{{ play_vars|dict2items}}"
+
+- name: "Set up defaults"
+  hosts: overcloud_nodes
+  tags: always
+  tasks:
+    - include_vars:
+        file: defaults/main.yml
+        name: play_vars
+
+    - set_fact: "{{item.key}}={{item.value}}"
+      loop: "{{ play_vars|dict2items}}"
+
 - name: "Check that collectd is running and generating any metrics"
   hosts: overcloud_nodes
   ignore_errors: true

--- a/tasks/test_collectd.yml
+++ b/tasks/test_collectd.yml
@@ -1,0 +1,30 @@
+---
+- name: "[Test] Check that collectd container is running."
+  shell: |
+    podman ps | grep collectd
+  register: podman_nodes
+  failed_when: podman_nodes.stdout_lines|length != 1
+
+- name: "[Test] Check for a non-zero number of metrics from collectd"
+  shell: |
+    podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
+  register: num_metrics
+  failed_when: "not (num_metrics.stdout|int !=0 )"
+
+
+- name: "[Debug] Check for a non-zero number of metrics from collectd"
+  debug:
+     var: num_metrics
+
+- name: "[Setup] Get the value of some metric from collectd"
+  shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | tail -1
+  register: met
+
+- name: "[Debug] Get the value of some metric from collectd"
+  debug:
+    var: met
+
+- name: "[Test] Get the value of some metric from collectd"
+  shell: podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
+  register: stat
+  failed_when: not(stat.stdout_lines|length == 1)

--- a/tasks/test_collectd.yml
+++ b/tasks/test_collectd.yml
@@ -1,13 +1,13 @@
 ---
 - name: "[Test] Check that collectd container is running."
   shell: |
-    podman ps | grep collectd
+    podman ps | grep {{ collectd_container_name }}
   register: podman_nodes
   failed_when: podman_nodes.stdout_lines|length != 1
 
 - name: "[Test] Check for a non-zero number of metrics from collectd"
   shell: |
-    podman exec collectd collectdctl -s /var/run/collectd-socket listval | wc -l
+    podman exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket listval | wc -l
   register: num_metrics
   failed_when: "not (num_metrics.stdout|int !=0 )"
 
@@ -17,7 +17,7 @@
      var: num_metrics
 
 - name: "[Setup] Get the value of some metric from collectd"
-  shell: podman exec collectd collectdctl -s /var/run/collectd-socket listval | tail -1
+  shell: podman exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket listval | tail -1
   register: met
 
 - name: "[Debug] Get the value of some metric from collectd"
@@ -25,6 +25,6 @@
     var: met
 
 - name: "[Test] Get the value of some metric from collectd"
-  shell: podman exec collectd collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
+  shell: podman exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket getval {{ met.stdout }}
   register: stat
   failed_when: not(stat.stdout_lines|length == 1)

--- a/tasks/test_qdr.yml
+++ b/tasks/test_qdr.yml
@@ -1,0 +1,24 @@
+---
+- name: "[Test] Check that qdr container is running."
+  shell: |
+    podman ps | grep metrics_qdr
+  register: podman_nodes
+  failed_when: podman_nodes.stdout_lines|length != 1
+
+- name: "[Setup] Get Qdr bus address"
+  shell: |
+      podman exec metrics_qdr cat /etc/qpid-dispatch/qdrouterd.conf | grep -5 listener | grep -3 "port: 5666" | grep host | awk '{print $2}'
+  register: bus_addr
+
+- name: "[Debug] Get Qdr bus address"
+  debug:
+    var: bus_addr
+
+- name: "[Test] Get number of messages received"
+  shell: podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
+  register: num_rx
+  failed_when: num_rx.stdout|int == 0 or num_rx.stdout_lines|length == 0
+
+- name: "[Debug] Get the number of messages received"
+  debug:
+    var: num_rx

--- a/tasks/test_qdr.yml
+++ b/tasks/test_qdr.yml
@@ -1,13 +1,13 @@
 ---
 - name: "[Test] Check that qdr container is running."
   shell: |
-    podman ps | grep metrics_qdr
+    podman ps | grep {{ qdr_container_name }}
   register: podman_nodes
   failed_when: podman_nodes.stdout_lines|length != 1
 
 - name: "[Setup] Get Qdr bus address"
   shell: |
-      podman exec metrics_qdr cat /etc/qpid-dispatch/qdrouterd.conf | grep -5 listener | grep -3 "port: 5666" | grep host | awk '{print $2}'
+      podman exec {{ qdr_container_name }} cat /etc/qpid-dispatch/qdrouterd.conf | grep -5 listener | grep -3 "port: 5666" | grep host | awk '{print $2}'
   register: bus_addr
 
 - name: "[Debug] Get Qdr bus address"
@@ -15,7 +15,7 @@
     var: bus_addr
 
 - name: "[Test] Get number of messages received"
-  shell: podman exec metrics_qdr qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
+  shell: podman exec {{ qdr_container_name }} qdstat -b {{ bus_addr.stdout }}:5666 -g | grep "Ingress Count" | awk '{print $3}'
   register: num_rx
   failed_when: num_rx.stdout|int == 0 or num_rx.stdout_lines|length == 0
 


### PR DESCRIPTION
Split the tests into separate task files so that they can be imported by other
testing tools.
Currently, it is planned that the collectd_config[1] and tripleo_collectd[2]
roles will use this in molecule and CI testing.
Later on, it'll be used to test other components intended for use with tripleo.

Allowing the changing of container names make it more re-usable as well.

There's a bit of a hack in stf_functional_tests.yaml to let the "default" vars be passed to  the tests; this is intended to be temporary and will be fixed later, it is in place at the moment to keep the behaviour of the stf_functional_tests.yaml identical to before.

[1] https://github.com/infrawatch/collectd-config-ansible-role
[2] https://github.com/infrawatch/tripleo-collectd-ansible-role