### PR TITLE
[collectd] Update test for metrics collected

### DIFF
--- a/tasks/test_collectd.yml
+++ b/tasks/test_collectd.yml
@@ -23,4 +23,4 @@
   command: |
     {{ container_bin }} exec {{ collectd_container_name }} collectdctl -s /var/run/collectd-socket getval {{ metrics.stdout_lines[-1] }}
   register: stat
-  failed_when: not(stat.stdout_lines|length == 1)
+  failed_when: stat.stdout_lines|length == 0


### PR DESCRIPTION
Some metrics produce more than one value at a time (e.g. rx and tx
values for network/if_octets)
The test will fail when the number of values returned is not one.
This change updates that test to make sure that there is a non-zero
number of values returned.