### PR TITLE
Add -C to grep commands for busybox compat

### DIFF
--- a/tasks/test_qdr.yml
+++ b/tasks/test_qdr.yml
@@ -7,7 +7,7 @@
 
 - name: "[Setup] Get Qdr bus address"
   shell: |
-      {{ container_bin }} exec {{ qdr_container_name }} cat /etc/qpid-dispatch/qdrouterd.conf | grep -5 listener | grep -3 "port: 5666" | grep host | awk '{print $2}'
+      {{ container_bin }} exec {{ qdr_container_name }} cat /etc/qpid-dispatch/qdrouterd.conf | grep -C 5 listener | grep -C 3 "port: 5666" | grep host | awk '{print $2}'
   register: bus_addr
 
 - name: "[Debug] Get Qdr bus address"


### PR DESCRIPTION
These tests were failing in our GHA-based CI because it has busybox instead of GNU grep
https://github.com/infrawatch/tripleo-qdr-ansible-role/runs/1689224720#step:5:404