### PR TITLE
Removing hardcoded Prometheus username and password

### DIFF
--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -45,6 +45,13 @@
   tasks:
     - name: "Run collectd Prometheus queries"  
       import_tasks: tasks/test_e2e.yml
+      vars:
+        prom_user: "{{ ( prom_secret.stdout_lines[0] | b64decode | split(':'))[0] }}"
+        prom_pass: "{{ prom_secret.stdout_lines[1] | b64decode }}"
+        prom_url: "{{ prom_route.stdout }}"
+        stf_user: "quicklab"
+        stf_host: "{{ stf_fqdn.stdout }}"
+
       tags:
         - custom-stf-ceph
         - stf-connectors-osp13-ffu

--- a/tasks/test_e2e.yml
+++ b/tasks/test_e2e.yml
@@ -1,39 +1,66 @@
-    - name: "Extract URL from stf-connectors template"
-      shell: grep interconnect /home/stack/virt/stf-connectors* | sed 's;.*\(-service-telemetry.*\);default-prometheus-proxy\1;'
-      register: prom_url
-      failed_when: "prom_url.stdout_lines|length == 0"
+    - name: "Copy quicklab key"
+      shell: curl https://gitlab.cee.redhat.com/cee_ops/quicklab/raw/master/docs/quicklab.key --output ~/.ssh/quicklab.key; chmod 600 ~/.ssh/quicklab.key
+          
+    - name: "Extract STF FQDN"
+      shell: grep interconnect /home/stack/virt/stf-connectors* | sed '/\:*\./s/^[^.]*\ //'
+      register: stf_fqdn
     - debug:
-        var: prom_url.stdout_lines
+        var: stf_fqdn.stdout
+ 
+    - name: Get the default-prometheus-htpasswd secret
+      shell:
+        cmd: |
+          ssh -i ~/.ssh/quicklab.key   {{ stf_user }}@{{ stf_host }}  oc get secret default-prometheus-htpasswd -ojson | jq '.data.auth, .data.password' |  sed 's/"//g'
+      register: prom_secret
+
+  
+    - debug:
+        var: prom_secret | string
+
+    - name: "Get the prom URL"
+      shell:
+        cmd: |
+          ssh -i ~/.ssh/quicklab.key  {{ stf_user }}@{{ stf_host }}  oc get route/default-prometheus-proxy -ojson | jq '.spec.host' | sed 's/"//g'
+      register: prom_route
 
     - debug:
-        msg: The URL is {{ prom_url.stdout_lines }}
+        var:  prom_route.stdout
 
+    - name: "Get the prom creds from the secret"
+      set_fact:
+        prom_user: "{{ ( prom_secret.stdout_lines[0] | b64decode | split(':'))[0] }}"
+        prom_pass: "{{ prom_secret.stdout_lines[1] | b64decode }}"
+
+    - debug: var=prom_user
+
+
+ 
     - name: "RHELOSP-37759"
-      shell: /usr/bin/curl -k -u "internal:1tp9zXur-t8Ve,wPkVgE" -g https://{{ prom_url.stdout_lines[0] }}/api/v1/query? --data-urlencode 'query=collectd_cpu_percent {plugin_instance="0"}[1m]' > /tmp/query_collectd_cpu_percent
+      shell: /usr/bin/curl -k -u "{{ prom_user}}:{{ prom_pass }}" -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=collectd_cpu_percent {plugin_instance="0"}[1m]' > /tmp/query_collectd_cpu_percent
       register: checkmyconf
       failed_when:
         - checkmyconf.rc !=0
 
     - name: "RHELOSP-57528"
-      shell: /usr/bin/curl -k -u "internal:1tp9zXur-t8Ve,wPkVgE" -g https://{{ prom_url.stdout_lines[0] }}/api/v1/query? --data-urlencode 'query=collectd_ceph_ceph_bytes {plugin_instance="ceph-osd.5"}[1m]' > /tmp/query_ceph_ceph_bytes
+      shell: /usr/bin/curl -k -u "{{ prom_user}}:{{ prom_pass }}" -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=collectd_ceph_ceph_bytes {plugin_instance="ceph-osd.5"}[1m]' > /tmp/query_ceph_ceph_bytes
       register: checkmyconf
       failed_when:
         - checkmyconf.rc !=0
     
     - name: "RHELOSP-57536"
-      shell: /usr/bin/curl -k -u "internal:1tp9zXur-t8Ve,wPkVgE" -g https://{{ prom_url.stdout_lines[0] }}/api/v1/query? --data-urlencode 'query=collectd_interface_if_packets_tx_total {type_instance="base"}[1m]' > /tmp/query_collectd_interface_tx_total
+      shell: /usr/bin/curl -k -u "{{ prom_user}}:{{ prom_pass }}" -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=collectd_interface_if_packets_tx_total {type_instance="base"}[1m]' > /tmp/query_collectd_interface_tx_total
       register: checkmyconf
       failed_when:
         - checkmyconf.rc !=0
     
     - name: "RHELOSP-37762"
-      shell: /usr/bin/curl -k -u "internal:1tp9zXur-t8Ve,wPkVgE" -g https://{{ prom_url.stdout_lines[0] }}/api/v1/query? --data-urlencode 'query=collectd_memory {plugin_instance="base"}[1m]' > /tmp/query_collectd_memory
+      shell: /usr/bin/curl -k -u "{{ prom_user}}:{{ prom_pass }}" -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=collectd_memory {plugin_instance="base"}[1m]' > /tmp/query_collectd_memory
       register: checkmyconf
       failed_when:
         - checkmyconf.rc !=0
 
     - name: "RHELOSP-117539"
-      shell: /usr/bin/curl -k -u "internal:1tp9zXur-t8Ve,wPkVgE" -g https://{{ prom_url.stdout_lines[0] }}/api/v1/query? --data-urlencode 'query=collectd_load_longterm {plugin_instance="base"}[1m]' > /tmp/query_load_longterm
+      shell: /usr/bin/curl -k -u "{{ prom_user}}:{{ prom_pass }}" -g https://{{ prom_url }}/api/v1/query? --data-urlencode 'query=collectd_load_longterm {plugin_instance="base"}[1m]' > /tmp/query_load_longterm
       register: checkmyconf
       failed_when:
         - checkmyconf.rc !=0


### PR DESCRIPTION
Currently in order to run Prometheus queries on the OCP cluster we are using hardcoded prometheus username and password that is basically exposed to everyone.

A new code will obtain these credentials by accessing OCP and store it in variables ,so it won't be exposed.