### PR TITLE
Increasing the loop size for snmpTraps test

### DIFF
--- a/roles/test_snmpTraps/tasks/main.yml
+++ b/roles/test_snmpTraps/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: "Interrupt metrics flow by preventing the QDR"
   ansible.builtin.shell:
     cmd: |
-      for i in {1..3}; do oc delete po -l application=default-interconnect; sleep 1; done
+      for i in {1..30}; do oc delete po -l application=default-interconnect; sleep 1; done
   changed_when: false
 
 - name: "Check for snmpTraps logs"


### PR DESCRIPTION
The default alertmanager route we describe in the docs requires 30s of disruption at minimum before it will send an alert. We don't want to sleep for long because the pod may be able to restart and transmit some data, so we should keep the sleep 1 but increase the loop size to guarantee that this lasts at least 30s.