### PR TITLE
Temporarily disabling recently added tests 

### DIFF
--- a/stf_functional_tests.yml
+++ b/stf_functional_tests.yml
@@ -53,25 +53,25 @@
         name: client_side_tests
         tasks_from: test_e2e
 
-    - name: "Test Alerts"
-      ansible.builtin.import_role:
-        name: test_alerts
-
-    - name: "Test metrics retention"
-      ansible.builtin.import_role:
-        name: test_metrics_retention
-
-    - name: "Test snmp traps"
-      ansible.builtin.import_role:
-        name: test_snmp_traps
-
-    - name: "Test HA"
-      ansible.builtin.import_role:
-        name: test_ha
-
-    - name: "Test observabilityStrategy"
-      ansible.builtin.import_role:
-        name: test_observability_strategy
+#    - name: "Test Alerts"
+#      ansible.builtin.import_role:
+#        name: test_alerts
+#
+#    - name: "Test metrics retention"
+#      ansible.builtin.import_role:
+#        name: test_metrics_retention
+#
+#    - name: "Test snmp traps"
+#      ansible.builtin.import_role:
+#        name: test_snmp_traps
+#
+#    - name: "Test HA"
+#      ansible.builtin.import_role:
+#        name: test_ha
+#
+#    - name: "Test observabilityStrategy"
+#      ansible.builtin.import_role:
+#        name: test_observability_strategy
   tags:
     - custom-stf-ceph
     - stf-connectors-osp13-ffu


### PR DESCRIPTION
Currently new functional tests that were recently added not reporting to Polarion.

They will be enabled when appropriate test cases will be added and test names will be changed accordingly. Right now it just create unneeded load on STF.