### PR TITLE
Adjusting inv file with credentials of new STF deployed on PSI

### DIFF
--- a/default.inv
+++ b/default.inv
@@ -49,5 +49,5 @@
 #ceph-0
 
 [stf]
-ocp_cluster  ansible_host="10.0.91.89" ansible_user="quicklab" ansible_ssh_private_key_file="playbooks/quicklab.key"
+ocp_cluster  ansible_host="10.0.77.132" ansible_user="cloud-user" ansible_ssh_private_key_file="playbooks/jumphost.key"
 


### PR DESCRIPTION
Long lived STF deployed on QuickLab is not available anymore. 
We deployed a new STF on PSI using stf-v-c and this patch adjusts inv file of functional tests to connect to the new STF.